### PR TITLE
We can use Network::Launch(false, getOptimalOrder()) now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__
 .python-version
 /build*
+.cache

--- a/include/Network.hpp
+++ b/include/Network.hpp
@@ -11,7 +11,6 @@
 #include <fstream>
 #include "intrusive_ptr_base.hpp"
 #include "utils/utils.hpp"
-#include "Network.hpp"
 #include "UniTensor.hpp"
 #include "contraction_tree.hpp"
 namespace cytnx{
@@ -94,7 +93,8 @@ namespace cytnx{
             virtual void Fromfile(const std::string& fname);
             virtual void FromString(const std::vector<std::string> &content);
             virtual void clear();
-            virtual UniTensor Launch(const bool &optimal=false);
+			virtual std::string getOptimalOrder();
+            virtual UniTensor Launch(const bool &optimal=false, const std::string& contract_order="");
             virtual void PrintNet(std::ostream &os);
             virtual boost::intrusive_ptr<Network_base> clone();
             virtual void Savefile(const std::string &fname);
@@ -123,7 +123,8 @@ namespace cytnx{
                 this->TOUT_iBondNum = 0;
                 this->ORDER_tokens.clear();
             }
-            UniTensor Launch(const bool &optimal=false);
+			std::string getOptimalOrder();
+        	UniTensor Launch(const bool &optimal=false, const std::string& contract_order="");
             boost::intrusive_ptr<Network_base> clone(){
                 RegularNetwork *tmp = new RegularNetwork();
                 tmp->name2pos = this->name2pos;

--- a/src/Network_base.cpp
+++ b/src/Network_base.cpp
@@ -30,7 +30,11 @@ namespace cytnx{
     void Network_base::clear(){
         cytnx_error_msg(true,"[ERROR][Network][Clear] call from uninitialize network.%s","\n");
     }
-    UniTensor Network_base::Launch(const bool &optimal){
+	std::string Network_base::getOptimalOrder(){
+        cytnx_error_msg(true,"[ERROR][Network][getOptimalOrder] call from uninitialize network.%s","\n");
+        return "";
+	}
+    UniTensor Network_base::Launch(const bool &optimal, const std::string& contract_order){
         cytnx_error_msg(true,"[ERROR][Network][Launch] call from uninitialize network.%s","\n");
         return UniTensor();
     }


### PR DESCRIPTION
Since we may encounter situations such as contracting networks with same structures over and over again, this PR adds Network::getOptimalOrder(), which allows us to store optimal contraction order, and then call Launch(optimal=false, saved_contract_order) now.