### PR TITLE
Add google benchmark and some simple benchmark test for Hstack, Vstack and Tensor.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ if(RUN_TESTS)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fprofile-arcs -ftest-coverage")
 	target_link_libraries(cytnx PUBLIC "-lgcov --coverage")
 	add_subdirectory(tests)
+	add_subdirectory(bm_tests)
 endif()
 
 include(GNUInstallDirs)
@@ -338,7 +339,7 @@ endif()
 
 
 ######################################################################
-### Get Gtest
+### Get Gtest & benchmark
 ######################################################################
 include(FetchContent)
 FetchContent_Declare(
@@ -347,7 +348,16 @@ FetchContent_Declare(
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+
+FetchContent_Declare(
+  googlebenchmark
+  GIT_REPOSITORY https://github.com/google/benchmark.git
+  GIT_TAG v1.7.1) # need master for benchmark::benchmark
+set(BENCHMARK_ENABLE_TESTING off)    # to suppress benchmark internal tests
+
+FetchContent_MakeAvailable(
+  googletest
+  googlebenchmark)
 
 
 ######################################################################

--- a/bm_tests/CMakeLists.txt
+++ b/bm_tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(
+  bm_test_main
+  bm_test_main.cpp
+  Tensor_bm.cpp
+  algo/Vstack_bm.cpp
+  algo/Hstack_bm.cpp
+
+)
+target_link_libraries(bm_test_main cytnx)
+target_link_libraries(bm_test_main benchmark::benchmark)

--- a/bm_tests/Tensor_bm.cpp
+++ b/bm_tests/Tensor_bm.cpp
@@ -1,0 +1,38 @@
+#include <benchmark/benchmark.h>
+#include <cytnx.hpp>
+ 
+// Cytnx test
+namespace BMTest_Tensor {
+
+static void BM_Cytnx_declare(benchmark::State& state) {
+  for (auto _: state) {
+    cytnx::Tensor A;
+  }
+}
+BENCHMARK(BM_Cytnx_declare);
+
+static void BM_Cytnx_contract(benchmark::State& state) {
+  auto A = cytnx::UniTensor(cytnx::ones({3, 3, 3}));
+  A.set_labels(std::vector<long int>{1l, 2l, 3l});
+  auto B = cytnx::UniTensor(cytnx::ones({3, 3, 3, 3}));
+  B.set_labels(std::vector<long int>{2l, 3l, 4l, 5l});
+  for (auto _: state) {
+    auto C = cytnx::Contract(A, B);
+  }
+}
+BENCHMARK(BM_Cytnx_contract);
+
+//test with several arguments, ex, bond dimension
+static void BM_ones(benchmark::State& state) {
+  int num_1 = state.range(0);
+  int num_2 = state.range(1);
+  for (auto _ : state) {
+    auto A = cytnx::UniTensor(cytnx::ones({num_1, num_2, 3}));
+  }
+}
+
+BENCHMARK(BM_ones)
+    ->Args({5, 3})
+    ->Args({10, 9});
+
+} //namespace

--- a/bm_tests/algo/Hstack_bm.cpp
+++ b/bm_tests/algo/Hstack_bm.cpp
@@ -1,0 +1,31 @@
+#include <benchmark/benchmark.h>
+#include <cytnx.hpp>
+ 
+namespace BMTest_Hstack {
+
+static void BM_Hstack_F64(benchmark::State& state) 
+{
+  //prepare data
+  auto D_row = state.range(0);
+  auto D_col = state.range(1);
+  auto tens_num = state.range(2);
+  std::vector<cytnx::Tensor> tens_list(tens_num);
+  for(int i = 0; i < tens_num; ++i) {
+    tens_list[i] = (i + 1) * cytnx::ones({D_row, D_col});
+  }
+
+  //start test here
+  for (auto _ : state) {
+    cytnx::Tensor hstack_tens = cytnx::algo::Hstack(tens_list);
+  }
+}
+
+BENCHMARK(BM_Hstack_F64)
+    //{D_row, D_col, tens_num}
+    ->Args({10, 10, 10})
+    ->Args({100, 100, 100})
+    ->Args({1000, 1000, 10});
+ 
+
+} //namespace
+

--- a/bm_tests/algo/Vstack_bm.cpp
+++ b/bm_tests/algo/Vstack_bm.cpp
@@ -1,0 +1,31 @@
+#include <benchmark/benchmark.h>
+#include <cytnx.hpp>
+ 
+namespace BMTest_Vstack {
+
+static void BM_Vstack_F64(benchmark::State& state) 
+{
+  //prepare data
+  auto D_row = state.range(0);
+  auto D_col = state.range(1);
+  auto tens_num = state.range(2);
+  std::vector<cytnx::Tensor> tens_list(tens_num);
+  for(int i = 0; i < tens_num; ++i) {
+    tens_list[i] = (i + 1) * cytnx::ones({D_row, D_col});
+  }
+
+  //start test here
+  for (auto _ : state) {
+    cytnx::Tensor vstack_tens = cytnx::algo::Vstack(tens_list);
+  }
+}
+
+BENCHMARK(BM_Vstack_F64)
+    //{D_row, D_col, tens_num}
+    ->Args({10, 10, 10})
+    ->Args({100, 100, 100})
+    ->Args({1000, 1000, 10});
+ 
+
+} //namespace
+

--- a/bm_tests/bm_test_main.cpp
+++ b/bm_tests/bm_test_main.cpp
@@ -1,0 +1,4 @@
+#include <benchmark/benchmark.h>
+
+//main
+BENCHMARK_MAIN();


### PR DESCRIPTION


1. modify the CMakeLists to add the google benchmark library automatically. For now, we specify the google benchmark library version is v1.7.1.
2. Add simple benchmark test for Hstack and Vstack, then if we need to optimize, we can check the benchmark test.
3. Add simple benchmark test for Tensor.