### PR TITLE
Cutensor

### DIFF
--- a/src/linalg/linalg_internal_gpu/CMakeLists.txt
+++ b/src/linalg/linalg_internal_gpu/CMakeLists.txt
@@ -55,4 +55,5 @@ target_sources_local(cytnx
     cuSum_internal.cu
     cuMaxMin_internal.cu
     cuKron_internal.cu
+    cuTensordot_internal.cu
 )

--- a/src/linalg/linalg_internal_gpu/cuTensordot_internal.cu
+++ b/src/linalg/linalg_internal_gpu/cuTensordot_internal.cu
@@ -1,0 +1,260 @@
+#include "cuTensordot_internal.hpp"
+#include "cytnx_error.hpp"
+#include "Type.hpp"
+#include "lapack_wrapper.hpp"
+#include <cutensor.h>
+
+#define HANDLE_ERROR(x)                                   \
+  {                                                       \
+    const cutensorStatus_t err = x;                       \
+    if (err != CUTENSOR_STATUS_SUCCESS) {                 \
+      printf("Error in line %d: %s\n", __LINE__, cutensorGetErrorString(err)); \
+      exit(-1);                                           \
+    }                                                     \
+  };
+
+namespace cytnx {
+
+  namespace linalg_internal {
+
+    inline void _cuTensordot_internal(Tensor &out, const Tensor &Lin, const Tensor &Rin,
+                              const std::vector<cytnx_uint64> &idxl,
+                              const std::vector<cytnx_uint64> &idxr,
+                              cudaDataType_t type,
+                              cutensorComputeType_t typeCompute,
+                              void *alpha, void *beta) {
+                              
+                                
+      // hostType alpha = (hostType){1.f, 0.f};
+      // hostType beta = (hostType){0.f, 0.f};
+
+      // mode stores the label of each dimesion, which the dimension of same label would be
+      // contracted label are encoded from 0 (new_label) contracted dimenstion, Tl's dimension, Tr's
+      // dimension
+
+      cytnx_error_msg((out.shape().size() > INT32_MAX),
+                      "contraction error: dimesion exceed INT32_MAX", 0);
+
+      // "mode" is label
+      std::vector<cytnx_int32> labelL(Lin.shape().size(), INT32_MAX);
+      std::vector<cytnx_int32> labelR(Rin.shape().size(), INT32_MAX);
+      std::vector<cytnx_int32> labelOut(Rin.shape().size()+Lin.shape().size()-2*idxl.size());
+
+
+      cytnx_int32 new_idx;
+      for (new_idx = 0; new_idx < idxl.size(); new_idx++) {
+        labelL[idxl[new_idx]] = new_idx;
+        labelR[idxr[new_idx]] = new_idx;
+      }
+      for (cytnx_int32 i = 0; i < labelL.size(); i++) {
+        if (labelL[i] == INT32_MAX) {
+          labelL[i] = new_idx;
+          new_idx++;
+        }
+      }
+      for (cytnx_int32 i = 0; i < labelR.size(); i++) {
+        if (labelR[i] == INT32_MAX) {
+          labelR[i] = new_idx;
+          new_idx++;
+        }
+      }
+
+      // range(idxl.size(), idxl.size()+out.shape().size())
+      // no vec_range fn with cytnx::int32 type, so I use the naive ways.
+      for (cytnx_int32 i = 0; i < labelOut.size(); i++) {
+        labelOut[i] = i + idxl.size();
+      }
+
+      void *outPtr = out._impl->storage()._impl->Mem;
+      void *lPtr = Lin._impl->storage()._impl->Mem;
+      void *rPtr = Rin._impl->storage()._impl->Mem;
+
+      int nlabelOut = labelOut.size();
+      int nlabelL = labelL.size();
+      int nlabelR = labelR.size();
+
+      std::vector<int64_t> extentOut(out.shape().cbegin(), out.shape().cend());
+      std::vector<int64_t> extentL(Lin.shape().cbegin(), Lin.shape().cend());
+      std::vector<int64_t> extentR(Rin.shape().cbegin(), Rin.shape().cend());
+
+      /*************************
+       * cuTENSOR
+       *************************/
+
+      cutensorHandle_t *handle;
+      HANDLE_ERROR(cutensorCreate(&handle));
+
+      /**********************
+       * Create Tensor Descriptors
+       **********************/
+
+      cutensorTensorDescriptor_t descL;
+      HANDLE_ERROR(cutensorInitTensorDescriptor(handle, &descL, nlabelL, extentL.data(),
+                                                NULL, /*stride*/
+                                                type, CUTENSOR_OP_IDENTITY));
+
+      cutensorTensorDescriptor_t descR;
+      HANDLE_ERROR(cutensorInitTensorDescriptor(handle, &descR, nlabelR, extentR.data(),
+                                                NULL, /*stride*/
+                                                type, CUTENSOR_OP_IDENTITY));
+
+      cutensorTensorDescriptor_t descOut;
+      HANDLE_ERROR(cutensorInitTensorDescriptor(handle, &descOut, nlabelOut, extentOut.data(),
+                                                NULL, /*stride*/
+                                                type, CUTENSOR_OP_IDENTITY));
+
+      /**********************************************
+       * Retrieve the memory alignment for each tensor
+       **********************************************/
+
+      uint32_t alignmentRequirementL;
+      HANDLE_ERROR(cutensorGetAlignmentRequirement(handle, lPtr, &descL, &alignmentRequirementL));
+
+      uint32_t alignmentRequirementR;
+      HANDLE_ERROR(cutensorGetAlignmentRequirement(handle, rPtr, &descR, &alignmentRequirementR));
+
+      uint32_t alignmentRequirementOut;
+      HANDLE_ERROR(cutensorGetAlignmentRequirement(handle, outPtr, &descOut, &alignmentRequirementOut));
+
+
+      /*******************************
+       * Create Contraction Descriptor
+       *******************************/
+
+      cutensorContractionDescriptor_t desc;
+      HANDLE_ERROR(cutensorInitContractionDescriptor(handle, 
+        &desc, 
+        &descL, labelL.data(), alignmentRequirementL, 
+        &descR, labelR.data(), alignmentRequirementR, 
+        &descOut, labelOut.data(), alignmentRequirementOut, 
+        &descOut, labelOut.data(), alignmentRequirementOut, 
+        typeCompute));
+
+      /**************************
+       * Set the algorithm to use
+       ***************************/
+
+      cutensorContractionFind_t find;
+      HANDLE_ERROR(cutensorInitContractionFind(handle, &find, CUTENSOR_ALGO_DEFAULT));
+
+      /**********************
+       * Query workspace
+       **********************/
+
+      uint64_t worksize = 0;
+      HANDLE_ERROR(cutensorContractionGetWorkspaceSize(handle, &desc, &find,
+                                                       CUTENSOR_WORKSPACE_RECOMMENDED, &worksize));
+
+      void *work = nullptr;
+      if (worksize > 0) {
+        if (cudaSuccess != cudaMalloc(&work, worksize)) {
+          work = nullptr;
+          worksize = 0;
+        }
+      }
+
+      /**************************
+       * Create Contraction Plan
+       **************************/
+
+      cutensorContractionPlan_t plan;
+      HANDLE_ERROR(cutensorInitContractionPlan(handle, &plan, &desc, &find, worksize));
+
+      /**********************
+       * Run
+       **********************/
+
+      HANDLE_ERROR(cutensorContraction(handle, &plan, alpha, lPtr, rPtr, beta, outPtr, outPtr,
+                                work, worksize, 0 /* stream */));
+
+      /*************************/
+
+      if (work) checkCudaErrors(cudaFree(work));
+      HANDLE_ERROR(cutensorDestroy(handle));
+
+    }
+
+    void cuTensordot_internal_cd(Tensor &out, const Tensor &Lin, const Tensor &Rin,
+                              const std::vector<cytnx_uint64> &idxl,
+                              const std::vector<cytnx_uint64> &idxr) {
+
+        typedef cuDoubleComplex hostType;
+        cudaDataType_t type = CUDA_C_64F;
+        cutensorComputeType_t typeCompute = CUTENSOR_COMPUTE_64F;
+
+        hostType alpha = {1., 0.};
+        hostType beta = {0., 0.};
+
+        _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
+    }
+    
+    void cuTensordot_internal_cf(Tensor &out,
+                              const Tensor &Lin,
+                              const Tensor &Rin, const std::vector<cytnx_uint64> &idxl, const std::vector<cytnx_uint64> &idxr) {
+        typedef cuFloatComplex hostType;
+        cudaDataType_t type = CUDA_C_32F;
+        cutensorComputeType_t typeCompute = CUTENSOR_COMPUTE_32F;
+        
+        hostType alpha = {1.f, 0.f};
+        hostType beta = {0.f, 0.f};
+
+        _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
+    }
+    
+    void cuTensordot_internal_d(Tensor &out,
+                              const Tensor &Lin,
+                              const Tensor &Rin, const std::vector<cytnx_uint64> &idxl, const std::vector<cytnx_uint64> &idxr)  {
+        typedef double hostType;
+        cudaDataType_t type = CUDA_C_64F;
+        cutensorComputeType_t typeCompute = CUTENSOR_COMPUTE_64F;
+
+        hostType alpha = 1.f;
+        hostType beta = 0.f;
+
+        _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
+    }
+    
+    void cuTensordot_internal_f(Tensor &out,
+                              const Tensor &Lin,
+                              const Tensor &Rin, const std::vector<cytnx_uint64> &idxl, const std::vector<cytnx_uint64> &idxr)  {
+        typedef float hostType;
+        cudaDataType_t type = CUDA_C_32F;
+        cutensorComputeType_t typeCompute = CUTENSOR_COMPUTE_32F;
+
+        hostType alpha = 1.f;
+        hostType beta = 0.f;
+
+        _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
+    }
+        
+    void cuTensordot_internal_u32(Tensor &out,
+                              const Tensor &Lin,
+                              const Tensor &Rin, const std::vector<cytnx_uint64> &idxl, const std::vector<cytnx_uint64> &idxr)  {
+        typedef cytnx_uint32 hostType;
+        cudaDataType_t type = CUDA_R_32U;
+
+        cutensorComputeType_t typeCompute = CUTENSOR_COMPUTE_32U;
+
+        hostType alpha = 1;
+        hostType beta = 0;
+
+        _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
+    }
+    
+    void cuTensordot_internal_i32(Tensor &out,
+                              const Tensor &Lin,
+                              const Tensor &Rin, const std::vector<cytnx_uint64> &idxl, const std::vector<cytnx_uint64> &idxr)  {
+        typedef cytnx_int32 hostType;
+        cudaDataType_t type = CUDA_R_32I;
+
+        cutensorComputeType_t typeCompute = CUTENSOR_COMPUTE_32I;
+
+        hostType alpha = 1;
+        hostType beta = 0;
+
+        _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
+    }
+
+  }  // namespace linalg_internal
+
+}  // namespace cytnx

--- a/src/linalg/linalg_internal_gpu/cuTensordot_internal.hpp
+++ b/src/linalg/linalg_internal_gpu/cuTensordot_internal.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include "Storage.hpp"
 #include "Type.hpp"
+#include "Tensor.hpp"
 
 namespace cytnx {
 
@@ -17,8 +18,25 @@ namespace cytnx {
                                  const Tensor &Lin,
                                  const Tensor &Rin, const std::vector<cytnx_uint64> &idxl, const std::vector<cytnx_uint64> &idxr);
 
-    
+    void cuTensordot_internal_cf(Tensor &out,
+                                 const Tensor &Lin,
+                                 const Tensor &Rin, const std::vector<cytnx_uint64> &idxl, const std::vector<cytnx_uint64> &idxr);
 
+    void cuTensordot_internal_d(Tensor &out,
+                                 const Tensor &Lin,
+                                 const Tensor &Rin, const std::vector<cytnx_uint64> &idxl, const std::vector<cytnx_uint64> &idxr);
+    
+    void cuTensordot_internal_f(Tensor &out,
+                                 const Tensor &Lin,
+                                 const Tensor &Rin, const std::vector<cytnx_uint64> &idxl, const std::vector<cytnx_uint64> &idxr);
+
+    void cuTensordot_internal_u32(Tensor &out,
+                                 const Tensor &Lin,
+                                 const Tensor &Rin, const std::vector<cytnx_uint64> &idxl, const std::vector<cytnx_uint64> &idxr);
+
+    void cuTensordot_internal_i32(Tensor &out,
+                                 const Tensor &Lin,
+                                 const Tensor &Rin, const std::vector<cytnx_uint64> &idxl, const std::vector<cytnx_uint64> &idxr);
 
   }  // namespace linalg_internal
 }  // namespace cytnx

--- a/src/linalg/linalg_internal_interface.cpp
+++ b/src/linalg/linalg_internal_interface.cpp
@@ -1302,6 +1302,15 @@ namespace cytnx {
       cuOuter_ii[Type.Bool][Type.Int16] = cuOuter_internal_bti16;
       cuOuter_ii[Type.Bool][Type.Bool] = cuOuter_internal_btb;
 
+#ifdef UNI_CUTENSOR
+      cuTensordot_ii = vector<Tensordotfunc_oii>(N_Type);
+      cuTensordot_ii[Type.ComplexDouble] = cuTensordot_internal_cd;
+      cuTensordot_ii[Type.ComplexFloat] = cuTensordot_internal_cf;
+      cuTensordot_ii[Type.Double] = cuTensordot_internal_d;
+      cuTensordot_ii[Type.Float] = cuTensordot_internal_f;
+      cuTensordot_ii[Type.Int32] = cuTensordot_internal_i32;
+      cuTensordot_ii[Type.Uint32] = cuTensordot_internal_u32;
+#endif
 #endif
     }
 

--- a/src/linalg/linalg_internal_interface.hpp
+++ b/src/linalg/linalg_internal_interface.hpp
@@ -59,6 +59,9 @@
   #include "linalg/linalg_internal_gpu/cuSum_internal.hpp"
   #include "linalg/linalg_internal_gpu/cuMaxMin_internal.hpp"
   #include "linalg/linalg_internal_gpu/cuKron_internal.hpp"
+#ifdef UNI_CUTENSOR
+  #include "linalg/linalg_internal_gpu/cuTensordot_internal.hpp"
+#endif
 #endif
 
 namespace cytnx {
@@ -159,7 +162,9 @@ namespace cytnx {
                            const std::vector<cytnx_uint64> &, const std::vector<cytnx_int64> &,
                            const cytnx_uint64 &, const cytnx_uint64 &);
 
-
+    typedef void (*Tensordotfunc_oii)(Tensor &out,
+                              const Tensor &Lin,
+                              const Tensor &Rin, const std::vector<cytnx_uint64> &idxl, const std::vector<cytnx_uint64> &idxr);
 
     class linalg_internal_interface {
      public:
@@ -218,6 +223,7 @@ namespace cytnx {
       std::vector<MaxMinfunc_oii> cuMM_ii;
       std::vector<MaxMinfunc_oii> cuSum_ii;
       std::vector<std::vector<Kronfunc_oii>> cuKron_ii;
+      std::vector<Tensordotfunc_oii> cuTensordot_ii;
 #endif
 
       linalg_internal_interface();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,9 @@
+if (USE_CUDA AND USE_CUTENSOR)      # cutensor related tests
+  set(additional_tests 
+      gpu_test/BlockUniTensor_test.cpp
+      gpu_test/DenseUniTensor_test.cpp)
+endif()
+
 add_executable(
   test_main
   test_tools.cpp
@@ -33,7 +39,10 @@ add_executable(
   algo_test/Vsplit_test.cpp
   algo_test/Vstack_test.cpp
 
+  ${additional_tests}
 )
+ 
+
 target_link_libraries(
   test_main
   gtest_main

--- a/tests/gpu_test/BlockUniTensor_test.cpp
+++ b/tests/gpu_test/BlockUniTensor_test.cpp
@@ -1,0 +1,50 @@
+#include "../BlockUniTensor_test.h"
+
+TEST_F(BlockUniTensorTest, contract1_cutn) {
+    // two sparse matrix
+
+    UT_contract_L1.set_labels({'a','b'});
+    UT_contract_R1.set_labels({'b','c'});
+    UT_contract_L1.to_(Device.cuda);
+    UT_contract_R1.to_(Device.cuda);
+
+    EXPECT_TRUE(UT_contract_L1.dtype() == Type.Double);
+    EXPECT_TRUE(UT_contract_R1.dtype() == Type.Double);
+    UniTensor out = UT_contract_L1.contract(UT_contract_R1);
+    auto outbks = out.get_blocks();
+    auto ansbks = UT_contract_ans1.get_blocks();
+    for(int i = 0; i < ansbks.size(); i++)
+        EXPECT_EQ(outbks[i].equiv(ansbks[i]), true);
+}
+
+TEST_F(BlockUniTensorTest, contract2_cutn) {
+    // two sparse matrix with degeneracy
+
+    UT_contract_L2.set_labels({'a','b'});
+    UT_contract_R2.set_labels({'b','c'});
+    UT_contract_L2.to_(Device.cuda);
+    UT_contract_R2.to_(Device.cuda);
+    EXPECT_TRUE(UT_contract_L2.dtype() == Type.Double);
+    EXPECT_TRUE(UT_contract_R2.dtype() == Type.Double);
+    UniTensor out = UT_contract_L2.contract(UT_contract_R2);
+    auto outbks = out.get_blocks();
+    auto ansbks = UT_contract_ans2.get_blocks();
+    for(int i = 0; i < ansbks.size(); i++)
+        EXPECT_EQ(outbks[i].equiv(ansbks[i]), true);
+}
+
+TEST_F(BlockUniTensorTest, contract3_cutn) {
+    //// two 3 legs tensor
+
+    UT_contract_L3.set_labels({'a','b','c'});
+    UT_contract_R3.set_labels({'c','d','e'});
+    UT_contract_L3.to_(Device.cuda);
+    UT_contract_R3.to_(Device.cuda);
+    // EXPECT_TRUE(UT_contract_L3.dtype() == Type.Double);
+    // EXPECT_TRUE(UT_contract_R3.dtype() == Type.Double);
+    UniTensor out = UT_contract_L3.contract(UT_contract_R3);
+    auto outbks = out.get_blocks();
+    auto ansbks = UT_contract_ans3.get_blocks();
+    for(int i = 0; i < ansbks.size(); i++)
+        EXPECT_EQ(outbks[i].equiv(ansbks[i]), true);
+}

--- a/tests/gpu_test/BlockUniTensor_test.cpp
+++ b/tests/gpu_test/BlockUniTensor_test.cpp
@@ -7,7 +7,6 @@ TEST_F(BlockUniTensorTest, contract1_cutn) {
     UT_contract_R1.set_labels({'b','c'});
     UT_contract_L1.to_(Device.cuda);
     UT_contract_R1.to_(Device.cuda);
-
     EXPECT_TRUE(UT_contract_L1.dtype() == Type.Double);
     EXPECT_TRUE(UT_contract_R1.dtype() == Type.Double);
     UniTensor out = UT_contract_L1.contract(UT_contract_R1);
@@ -40,8 +39,8 @@ TEST_F(BlockUniTensorTest, contract3_cutn) {
     UT_contract_R3.set_labels({'c','d','e'});
     UT_contract_L3.to_(Device.cuda);
     UT_contract_R3.to_(Device.cuda);
-    // EXPECT_TRUE(UT_contract_L3.dtype() == Type.Double);
-    // EXPECT_TRUE(UT_contract_R3.dtype() == Type.Double);
+    EXPECT_TRUE(UT_contract_L3.dtype() == Type.Double);
+    EXPECT_TRUE(UT_contract_R3.dtype() == Type.Double);
     UniTensor out = UT_contract_L3.contract(UT_contract_R3);
     auto outbks = out.get_blocks();
     auto ansbks = UT_contract_ans3.get_blocks();

--- a/tests/gpu_test/DenseUniTensor_test.cpp
+++ b/tests/gpu_test/DenseUniTensor_test.cpp
@@ -1,0 +1,44 @@
+#include "../DenseUniTensor_test.h"
+
+using namespace std;
+using namespace cytnx;
+using namespace std::complex_literals;
+
+TEST_F(DenseUniTensorTest, contract1_cutn) {
+    ut1.set_labels({"a","b","c","d"});
+    ut2.set_labels({"a","aa","bb","cc"});
+    ut1.to_(Device.cuda);
+    ut2.to_(Device.cuda);
+    EXPECT_TRUE(ut1.dtype() == Type.ComplexDouble);
+    EXPECT_TRUE(ut2.dtype() == Type.ComplexDouble);
+    UniTensor out = ut1.contract(ut2);
+    auto outbk = out.get_block_();
+    auto ansbk = contres1.get_block_();
+    EXPECT_TRUE(outbk.equiv(ansbk));
+}
+
+TEST_F(DenseUniTensorTest, contract2_cutn) {
+    ut1.set_labels({"a","b","c","d"});
+    ut2.set_labels({"a","b","bb","cc"});
+    ut1.to_(Device.cuda);
+    ut2.to_(Device.cuda);
+    EXPECT_TRUE(ut1.dtype() == Type.ComplexDouble);
+    EXPECT_TRUE(ut2.dtype() == Type.ComplexDouble);
+    UniTensor out = ut1.contract(ut2);
+    auto outbk = out.get_block_();
+    auto ansbk = contres2.get_block_();
+    EXPECT_TRUE(outbk.equiv(ansbk));
+}
+
+TEST_F(DenseUniTensorTest, contract3_cutn) {
+    ut1.set_labels({"a","b","c","d"});
+    ut2.set_labels({"a","b","c","cc"});
+    ut1.to_(Device.cuda);
+    ut2.to_(Device.cuda);
+    EXPECT_TRUE(ut1.dtype() == Type.ComplexDouble);
+    EXPECT_TRUE(ut2.dtype() == Type.ComplexDouble);
+    UniTensor out = ut1.contract(ut2);
+    auto outbk = out.get_block_();
+    auto ansbk = contres3.get_block_();
+    EXPECT_TRUE(outbk.equiv(ansbk));
+}


### PR DESCRIPTION
Use nvidia cutensor libarary to perform tensor contraction

About implementation:
* Some data types are not supported by the library, these types will fallback to original implementation.
(Unsupported types: Uint64, Int64, Uint16, Int16, Bool)

About test:
* I have add a folder for gpu tests (```gpu_test```) under the ```test``` directory.
* I have modified the tests/CMakeLists.txt to turn on/off the GPU related tests according to the compling flags.