### PR TITLE
fix some gpu tests

### DIFF
--- a/tests/gpu/BlockUniTensor_test.cpp
+++ b/tests/gpu/BlockUniTensor_test.cpp
@@ -42,15 +42,16 @@ TEST_F(BlockUniTensorTest, gpu_relabels){
   EXPECT_EQ(BUT1.labels()[1],"b");
   EXPECT_EQ(BUT1.labels()[2],"cd");
   EXPECT_EQ(BUT1.labels()[3],"d");
-  BUT1 = BUT1.relabels({1,-1,2,1000});
+  BUT1 = BUT1.relabels({"1","-1","2","1000"});
   EXPECT_EQ(BUT1.labels()[0],"1");
   EXPECT_EQ(BUT1.labels()[1],"-1");
   EXPECT_EQ(BUT1.labels()[2],"2");
   EXPECT_EQ(BUT1.labels()[3],"1000");
+  
   EXPECT_THROW(BUT1.relabels({"a","a","b","c"}), std::logic_error);
-  EXPECT_THROW(BUT1.relabels({1,1,0,-1}), std::logic_error);
+  EXPECT_THROW(BUT1.relabels({"1","1","0","-1"}), std::logic_error);
   EXPECT_THROW(BUT1.relabels({"a"}), std::logic_error);
-  EXPECT_THROW(BUT1.relabels({1,2}), std::logic_error);
+  EXPECT_THROW(BUT1.relabels({"1","2"}), std::logic_error);
   EXPECT_THROW(BUT1.relabels({"a","b","c","d","e"}), std::logic_error);
 }
 TEST_F(BlockUniTensorTest, gpu_relabels_){
@@ -59,15 +60,15 @@ TEST_F(BlockUniTensorTest, gpu_relabels_){
   EXPECT_EQ(BUT1.labels()[1],"b");
   EXPECT_EQ(BUT1.labels()[2],"cd");
   EXPECT_EQ(BUT1.labels()[3],"d");
-  BUT1.relabels_({1,-1,2,1000});
+  BUT1.relabels_({"1","-1","2","1000"});
   EXPECT_EQ(BUT1.labels()[0],"1");
   EXPECT_EQ(BUT1.labels()[1],"-1");
   EXPECT_EQ(BUT1.labels()[2],"2");
   EXPECT_EQ(BUT1.labels()[3],"1000");
   EXPECT_THROW(BUT1.relabels_({"a","a","b","c"}), std::logic_error);
-  EXPECT_THROW(BUT1.relabels_({1,1,0,-1}), std::logic_error);
+  EXPECT_THROW(BUT1.relabels_({"1","1","0","-1"}), std::logic_error);
   EXPECT_THROW(BUT1.relabels_({"a"}), std::logic_error);
-  EXPECT_THROW(BUT1.relabels_({1,2}), std::logic_error);
+  EXPECT_THROW(BUT1.relabels_({"1","2"}), std::logic_error);
   EXPECT_THROW(BUT1.relabels_({"a","b","c","d","e"}), std::logic_error);
 }
 
@@ -76,19 +77,26 @@ TEST_F(BlockUniTensorTest, gpu_relabel){
   BUT1 = BUT1.relabel("1", "b");
   BUT1 = BUT1.relabel("2", "d");
   BUT1 = BUT1.relabel("3", "de");
+
   BUT1 = BUT1.relabel("b", "ggg");
+
   EXPECT_EQ(BUT1.labels()[0],"a");
   EXPECT_EQ(BUT1.labels()[1],"ggg");
   EXPECT_EQ(BUT1.labels()[2],"d");
   EXPECT_EQ(BUT1.labels()[3],"de");
+
   BUT1 = BUT1.relabel(0,"ccc");
   EXPECT_EQ(BUT1.labels()[0],"ccc");
-  BUT1 = BUT1.relabel(0,-1);
-  EXPECT_EQ(BUT1.labels()[0],"-1");
-  BUT1 = BUT1.relabel(1,-199922);
+
+  BUT1 = BUT1.relabel(3,"-1");
+  EXPECT_EQ(BUT1.labels()[3],"-1");
+
+  BUT1 = BUT1.relabel(1,"-199922");
   EXPECT_EQ(BUT1.labels()[1],"-199922");
+
   BUT1 = BUT1.relabel("-1","0");
-  EXPECT_EQ(BUT1.labels()[0],"0");
+  EXPECT_EQ(BUT1.labels()[3],"0");
+
   // BUT1.relabel(0,'a');
   // EXPECT_EQ(BUT1.labels()[0],"a");
   EXPECT_THROW(BUT1.relabel(5,"a"),std::logic_error);
@@ -99,23 +107,29 @@ TEST_F(BlockUniTensorTest, gpu_relabel){
   // EXPECT_THROW(BUT1.relabel(5,'a'),std::logic_error);
 }
 TEST_F(BlockUniTensorTest, gpu_relabel_){
+
   BUT1.relabel_("0", "a");
   BUT1.relabel_("1", "b");
   BUT1.relabel_("2", "d");
   BUT1.relabel_("3", "de");
   BUT1.relabel_("b", "ggg");
+
   EXPECT_EQ(BUT1.labels()[0],"a");
   EXPECT_EQ(BUT1.labels()[1],"ggg");
   EXPECT_EQ(BUT1.labels()[2],"d");
   EXPECT_EQ(BUT1.labels()[3],"de");
+
   BUT1.relabel_(0,"ccc");
   EXPECT_EQ(BUT1.labels()[0],"ccc");
-  BUT1.relabel_(0,-1);
-  EXPECT_EQ(BUT1.labels()[0],"-1");
-  BUT1.relabel_(1,-199922);
+
+  BUT1.relabel_(3,"-1");
+  EXPECT_EQ(BUT1.labels()[3],"-1");
+
+  BUT1.relabel_(1,"-199922");
   EXPECT_EQ(BUT1.labels()[1],"-199922");
+
   BUT1.relabel_("-1","0");
-  EXPECT_EQ(BUT1.labels()[0],"0");
+  EXPECT_EQ(BUT1.labels()[3],"0");
   EXPECT_THROW(BUT1.relabel_(5,"a"),std::logic_error);
   EXPECT_THROW(BUT1.relabel_(-1,"a"),std::logic_error);
   // EXPECT_THROW(BUT1.relabel(0,"a").relabel(1,"a"),std::logic_error);
@@ -362,7 +376,7 @@ TEST_F(BlockUniTensorTest, gpu_device) {
 }
 
 TEST_F(BlockUniTensorTest, gpu_device_str){
-    EXPECT_EQ(Spf.device_str(), "cytnx device: CUDA");
+    EXPECT_EQ(Spf.device_str().substr(0, 18), "cytnx device: CUDA");
 }
 
 TEST_F(BlockUniTensorTest, gpu_is_blockform) {
@@ -372,7 +386,7 @@ TEST_F(BlockUniTensorTest, gpu_is_blockform) {
 
 TEST_F(BlockUniTensorTest, gpu_is_contiguous) {
     EXPECT_EQ(Spf.is_contiguous(), true);
-    auto Spf_new = Spf.permute({2,1,0},1,false);
+    auto Spf_new = Spf.permute({2,1,0},1);
     EXPECT_EQ(Spf_new.is_contiguous(), false);
 }
 
@@ -656,8 +670,8 @@ TEST_F(BlockUniTensorTest, gpu_permute_2) {
 TEST_F(BlockUniTensorTest, gpu_contract1) {
     // two sparse matrix
 
-    UT_contract_L1.set_labels({'a','b'});
-    UT_contract_R1.set_labels({'b','c'});
+    UT_contract_L1.set_labels({"a","b"});
+    UT_contract_R1.set_labels({"b","c"});
     UniTensor out = UT_contract_L1.contract(UT_contract_R1);
     auto outbks = out.get_blocks();
     auto ansbks = UT_contract_ans1.get_blocks();
@@ -668,8 +682,8 @@ TEST_F(BlockUniTensorTest, gpu_contract1) {
 TEST_F(BlockUniTensorTest, gpu_contract2) {
     // two sparse matrix with degeneracy
 
-    UT_contract_L2.set_labels({'a','b'});
-    UT_contract_R2.set_labels({'b','c'});
+    UT_contract_L2.set_labels({"a","b"});
+    UT_contract_R2.set_labels({"b","c"});
     UniTensor out = UT_contract_L2.contract(UT_contract_R2);
     auto outbks = out.get_blocks();
     auto ansbks = UT_contract_ans2.get_blocks();
@@ -681,8 +695,8 @@ TEST_F(BlockUniTensorTest, gpu_contract2) {
 TEST_F(BlockUniTensorTest, gpu_contract3) {
     //// two 3 legs tensor
 
-    UT_contract_L3.set_labels({'a','b','c'});
-    UT_contract_R3.set_labels({'c','d','e'});
+    UT_contract_L3.set_labels({"a","b","c"});
+    UT_contract_R3.set_labels({"c","d","e"});
     UniTensor out = UT_contract_L3.contract(UT_contract_R3);
     auto outbks = out.get_blocks();
     auto ansbks = UT_contract_ans3.get_blocks();

--- a/tests/gpu/BlockUniTensor_test.h
+++ b/tests/gpu/BlockUniTensor_test.h
@@ -76,10 +76,10 @@ class BlockUniTensorTest : public ::testing::Test {
   Bond C3B2 = Bond(BD_IN, {Qs(0), Qs(1), Qs(0), Qs(1)}, {1,2,3,4});
   Bond C3B3 = Bond(BD_OUT, {Qs(0), Qs(1), Qs(2)}, {1,2,3});
 
-  UniTensor Spf = UniTensor({phy,phy.redirect(),aux},{1,2,3},1,Type.Float,Device.cpu,false).to(cytnx::Device.cuda);
-  UniTensor Spd = UniTensor({phy,phy.redirect(),aux},{1,2,3},1,Type.Double,Device.cpu,false).to(cytnx::Device.cuda);
-  UniTensor Spcf = UniTensor({phy,phy.redirect(),aux},{1,2,3},1,Type.ComplexFloat,Device.cpu,false).to(cytnx::Device.cuda);
-  UniTensor Spcd = UniTensor({phy,phy.redirect(),aux},{1,2,3},1,Type.ComplexDouble,Device.cpu,false).to(cytnx::Device.cuda);
+  UniTensor Spf = UniTensor({phy,phy.redirect(),aux},{"1","2","3"},1,Type.Float,Device.cpu,false).to(cytnx::Device.cuda);
+  UniTensor Spd = UniTensor({phy,phy.redirect(),aux},{"1","2","3"},1,Type.Double,Device.cpu,false).to(cytnx::Device.cuda);
+  UniTensor Spcf = UniTensor({phy,phy.redirect(),aux},{"1","2","3"},1,Type.ComplexFloat,Device.cpu,false).to(cytnx::Device.cuda);
+  UniTensor Spcd = UniTensor({phy,phy.redirect(),aux},{"1","2","3"},1,Type.ComplexDouble,Device.cpu,false).to(cytnx::Device.cuda);
 
   UniTensor UT_pB = UniTensor({pBI,pBJ,pBK}).to(cytnx::Device.cuda);
   UniTensor UT_pB_ans = UniTensor({pBI,pBJ,pBK}).to(cytnx::Device.cuda);

--- a/tests/gpu/DenseUniTensor_test.cpp
+++ b/tests/gpu/DenseUniTensor_test.cpp
@@ -23,11 +23,11 @@ TEST_F(DenseUniTensorTest, gpu_relabels){
   EXPECT_EQ(utzero3456.labels()[1],"b");
   EXPECT_EQ(utzero3456.labels()[2],"cd");
   EXPECT_EQ(utzero3456.labels()[3],"d");
-  utzero3456 = utzero3456.relabels({1,-1,2,1000});
+  utzero3456 = utzero3456.relabels({"1","-1","2","1000"});
   EXPECT_THROW(utzero3456.relabels({"a","a","b","c"}), std::logic_error);
-  EXPECT_THROW(utzero3456.relabels({1,1,0,-1}), std::logic_error);
+  EXPECT_THROW(utzero3456.relabels({"1","1","0","-1"}), std::logic_error);
   EXPECT_THROW(utzero3456.relabels({"a"}), std::logic_error);
-  EXPECT_THROW(utzero3456.relabels({1,2}), std::logic_error);
+  EXPECT_THROW(utzero3456.relabels({"1","2"}), std::logic_error);
   EXPECT_THROW(utzero3456.relabels({"a","b","c","d","e"}), std::logic_error);
 }
 TEST_F(DenseUniTensorTest, gpu_relabels_){
@@ -36,11 +36,11 @@ TEST_F(DenseUniTensorTest, gpu_relabels_){
   EXPECT_EQ(utzero3456.labels()[1],"b");
   EXPECT_EQ(utzero3456.labels()[2],"cd");
   EXPECT_EQ(utzero3456.labels()[3],"d");
-  utzero3456.relabels_({1,-1,2,1000});
+  utzero3456.relabels_({"1","-1","2","1000"});
   EXPECT_THROW(utzero3456.relabels_({"a","a","b","c"}), std::logic_error);
-  EXPECT_THROW(utzero3456.relabels_({1,1,0,-1}), std::logic_error);
+  EXPECT_THROW(utzero3456.relabels_({"1","1","0","-1"}), std::logic_error);
   EXPECT_THROW(utzero3456.relabels_({"a"}), std::logic_error);
-  EXPECT_THROW(utzero3456.relabels_({1,2}), std::logic_error);
+  EXPECT_THROW(utzero3456.relabels_({"1","2"}), std::logic_error);
   EXPECT_THROW(utzero3456.relabels_({"a","b","c","d","e"}), std::logic_error);
 }
 
@@ -50,18 +50,20 @@ TEST_F(DenseUniTensorTest, gpu_relabel){
   utzero3456 = utzero3456.relabel("2", "d");
   utzero3456 = utzero3456.relabel("3", "de");
   utzero3456 = utzero3456.relabel("b", "ggg");
+
   EXPECT_EQ(utzero3456.labels()[0],"a");
   EXPECT_EQ(utzero3456.labels()[1],"ggg");
   EXPECT_EQ(utzero3456.labels()[2],"d");
   EXPECT_EQ(utzero3456.labels()[3],"de");
   utzero3456 = utzero3456.relabel(0,"ccc");
   EXPECT_EQ(utzero3456.labels()[0],"ccc");
-  utzero3456 = utzero3456.relabel(0,-1);
+  utzero3456 = utzero3456.relabel(0,"-1");
   EXPECT_EQ(utzero3456.labels()[0],"-1");
-  utzero3456 = utzero3456.relabel(1,-199922);
+  utzero3456 = utzero3456.relabel(1,"-199922");
   EXPECT_EQ(utzero3456.labels()[1],"-199922");
   utzero3456 = utzero3456.relabel("-1","0");
   EXPECT_EQ(utzero3456.labels()[0],"0");
+
   // utzero3456.relabel(0,'a');
   // EXPECT_EQ(utzero3456.labels()[0],"a");
   EXPECT_THROW(utzero3456.relabel(5,"a"),std::logic_error);
@@ -83,9 +85,9 @@ TEST_F(DenseUniTensorTest, gpu_relabel_){
   EXPECT_EQ(utzero3456.labels()[3],"de");
   utzero3456.relabel_(0,"ccc");
   EXPECT_EQ(utzero3456.labels()[0],"ccc");
-  utzero3456.relabel_(0,-1);
+  utzero3456.relabel_(0,"-1");
   EXPECT_EQ(utzero3456.labels()[0],"-1");
-  utzero3456.relabel_(1,-199922);
+  utzero3456.relabel_(1,"-199922");
   EXPECT_EQ(utzero3456.labels()[1],"-199922");
   utzero3456.relabel_("-1","0");
   EXPECT_EQ(utzero3456.labels()[0],"0");
@@ -247,7 +249,7 @@ TEST_F(DenseUniTensorTest, gpu_device) {
 }
 
 TEST_F(DenseUniTensorTest, gpu_device_str){
-    EXPECT_EQ(Spf.device_str(), "cytnx device: CUDA");
+    EXPECT_EQ(Spf.device_str().substr(0, 18), "cytnx device: CUDA");
 }
 
 TEST_F(DenseUniTensorTest, gpu_is_blockform) {
@@ -257,7 +259,7 @@ TEST_F(DenseUniTensorTest, gpu_is_blockform) {
 
 TEST_F(DenseUniTensorTest, gpu_is_contiguous) {
     EXPECT_EQ(Spf.is_contiguous(), true);
-    auto Spf_new = Spf.permute({2,1,0},1,false);
+    auto Spf_new = Spf.permute({2,1,0},1);
     EXPECT_EQ(Spf_new.is_contiguous(), false);
 }
 

--- a/tests/gpu/DenseUniTensor_test.h
+++ b/tests/gpu/DenseUniTensor_test.h
@@ -25,10 +25,10 @@ class DenseUniTensorTest : public ::testing::Test {
   Tensor tzero345 = zeros({3, 4, 5}).astype(Type.ComplexDouble).to(cytnx::Device.cuda);
   Tensor tar345 = arange({3*4*5}).reshape({3,4,5}).astype(Type.ComplexDouble).to(cytnx::Device.cuda);
 
-  UniTensor Spf = UniTensor({phy,phy.redirect(),aux},{1,2,3},1,Type.Float,Device.cpu,false).to(cytnx::Device.cuda);
-  UniTensor Spd = UniTensor({phy,phy.redirect(),aux},{1,2,3},1,Type.Double,Device.cpu,false).to(cytnx::Device.cuda);
-  UniTensor Spcf = UniTensor({phy,phy.redirect(),aux},{1,2,3},1,Type.ComplexFloat,Device.cpu,false).to(cytnx::Device.cuda);
-  UniTensor Spcd = UniTensor({phy,phy.redirect(),aux},{1,2,3},1,Type.ComplexDouble,Device.cpu,false).to(cytnx::Device.cuda);
+  UniTensor Spf = UniTensor({phy,phy.redirect(),aux},{"1","2","3"},1,Type.Float,Device.cpu,false).to(cytnx::Device.cuda);
+  UniTensor Spd = UniTensor({phy,phy.redirect(),aux},{"1","2","3"},1,Type.Double,Device.cpu,false).to(cytnx::Device.cuda);
+  UniTensor Spcf = UniTensor({phy,phy.redirect(),aux},{"1","2","3"},1,Type.ComplexFloat,Device.cpu,false).to(cytnx::Device.cuda);
+  UniTensor Spcd = UniTensor({phy,phy.redirect(),aux},{"1","2","3"},1,Type.ComplexDouble,Device.cpu,false).to(cytnx::Device.cuda);
 
   UniTensor ut1,ut2,contres1,contres2,contres3,dense4trtensor,densetr;
   UniTensor ut3,ut4,permu1,permu2;

--- a/tests/gpu/linalg_test/Svd_test.cpp
+++ b/tests/gpu/linalg_test/Svd_test.cpp
@@ -405,7 +405,7 @@ void Check_UU_VV_Identity(const UniTensor& Tin, const std::vector<UniTensor>& To
   const UniTensor& U = Tout[1];
   const UniTensor& V = Tout[2];
   auto UD = U.Dagger();
-  UD.set_labels({0, 1, 9});
+  UD.set_labels({"0", "1", "9"});
   UD.permute_({2, 0, 1}, 1);
   auto UUD = Contract(U, UD);
 }


### PR DESCRIPTION
Many test cases on the cpu version has been changed. But that of gpu remains unmodified, so gpu tests fail to compile.
I'm not sure the direct copy from modified test of cpu version to gpu is okay. So I send a pull request to make sure the action is approvable.
By the way, two test cases "BlockUniTensorTest.gpu_device_str" and "DenseUniTensorTest.gpu_device_str" has been fixed. (the device_str would be attached with gpu id)